### PR TITLE
create private key from node's hsm secret

### DIFF
--- a/src/lib/utils.py
+++ b/src/lib/utils.py
@@ -1,6 +1,8 @@
 """utility functions"""
 
 from coincurve import PublicKey
+from pyln.client import Plugin
+import os
 
 
 def get_hex_pubkey(privkey: str):
@@ -12,3 +14,45 @@ def get_hex_pubkey(privkey: str):
         privkey_bytes).format().hex()
     x_only_hex_pubkey = compressed_hex_pubkey[2:]
     return x_only_hex_pubkey
+
+
+def generate_keypair(plugin: Plugin) -> tuple[bytes, bytes]:
+    """
+    Use the node's hsm secret to generate a keypair
+
+    Returns:
+        privkey: bytes
+        pubkey: bytes
+    """
+
+    random_hex = os.urandom(32).hex()
+
+    privkey_hex = plugin.rpc.makesecret(hex=random_hex)["secret"]
+    privkey_bytes = bytes.fromhex(privkey_hex)
+
+    pubkey = PublicKey.from_secret(privkey_bytes).format()
+    x_only_pubkey = pubkey[1:]
+
+    return privkey_bytes, x_only_pubkey
+
+
+def get_keypair(plugin: Plugin):
+    """
+    Get the privkey and pubkey from the plugin's datastore or generate a new one
+    """
+    datastore_key = ["nwc", "key", "v0"]
+
+    datastore = plugin.rpc.listdatastore(key=datastore_key)["datastore"]
+
+    privkey = None
+    pubkey = None
+
+    if len(datastore) is not 0:
+        privkey = bytes.fromhex(datastore[0]["string"])
+        pubkey = PublicKey.from_secret(privkey).format()[1:]
+
+    else:
+        privkey, pubkey = generate_keypair(plugin)
+        plugin.rpc.datastore(key=datastore_key, string=privkey.hex())
+
+    return privkey, pubkey

--- a/src/nwc.py
+++ b/src/nwc.py
@@ -11,6 +11,7 @@ try:
     import json
     from lib.nip47 import URIOptions, NIP47URI
     from lib.wallet import Wallet
+    from lib.utils import get_keypair
     from utilities.rpc_plugin import plugin
 except ImportError as e:
     # TODO: if something isn't installed then disable the plugin
@@ -24,8 +25,10 @@ DEFAULT_RELAY = 'wss://relay.getalby.com/v1'
 def init(options, configuration, plugin: Plugin):
     """initialize the plugin"""
     # TODO: create a Main class that implements Keys, Wallet, Plugin
-    plugin.privkey = bytes.fromhex("000001")  # TODO: set a real privkey
-    plugin.pubkey = PublicKey.from_secret(plugin.privkey).format().hex()[2:]
+
+    privkey, pubkey = get_keypair(plugin)
+    plugin.privkey = privkey
+    plugin.pubkey = pubkey.hex()
 
     # create a Wallet instance to listent for incoming nip47 requests
     url = DEFAULT_RELAY


### PR DESCRIPTION
Create a random private key using the [node's hsm secret](https://docs.corelightning.org/reference/lightning-makesecret). 

Using the hsm secret may be unnecessary, but why not?

This stores the generated private key in the node's database and loads/creates the private key when the plugin is initialized.

